### PR TITLE
fix: index cache

### DIFF
--- a/app/backend/app.ts
+++ b/app/backend/app.ts
@@ -25,15 +25,7 @@ app.context.abort = function (status: number, errors: ErrorArray) {
 };
 
 app
-  .use(
-    mount(
-      config.appUrl,
-      serve(path.join(__dirname, '/static'), {
-        // 1 month
-        maxAge: 2629800000,
-      }),
-    ),
-  )
+  .use(mount(config.appUrl, serve(path.join(__dirname, '/static'))))
   .use(async (ctx, next) => {
     try {
       await next();


### PR DESCRIPTION
Remove the `maxAge` directive for static content.
- It's bad to be caching the index page.
- CF handles all the caching anyway and offers a nicer way to do that.
