### PR TITLE
move resetTooltip() in copy() to finally block to keep user activation

### DIFF
--- a/app/components/InputTextbox.vue
+++ b/app/components/InputTextbox.vue
@@ -147,7 +147,6 @@ const resetTooltip = useDebounceFn(() => {
 
 async function copy() {
   showTooltip.value = true;
-  await resetTooltip();
   try {
     await navigator.clipboard.writeText(props.modelValue);
     tooltipState.value = true;
@@ -155,6 +154,9 @@ async function copy() {
   } catch (_) {
     tooltipState.value = false;
     emit('copyFail');
+  }
+  finally {
+    await resetTooltip();
   }
 }
 


### PR DESCRIPTION
I was never able to copy to clipboard successfully from input boxes on Lineage Builder, and found out why. The `Clipboard.writeText()` API requires [User Activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation) in order to copy to clipboard, a property that expires after a timeout. Some browsers enforce this more strictly, mine included. (Browser:  Google Chrome Version 140.0.7339.127 (Official Build) (64-bit) on Arch Linux, kernel 6.16.7-arch1-1) By the time the timeout on `resetTooltip()` was up, user activation was expired and it failed to copy. I moved `resetTooltip()` into a `finally` block, tested it in the docker container, and was able to copy successfully.